### PR TITLE
Implement virtfs skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+/virtfs/target/
+/virtfs/Cargo.lock
+**/target/
+**/*.rs.bk
+virtfs/virtfs-common/src/virtfs.rs

--- a/virtfs/virtfs-common/Cargo.toml
+++ b/virtfs/virtfs-common/Cargo.toml
@@ -4,3 +4,8 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+tonic = "0.11"
+prost = "0.12"
+
+[build-dependencies]
+tonic-build = "0.11"

--- a/virtfs/virtfs-common/build.rs
+++ b/virtfs/virtfs-common/build.rs
@@ -1,0 +1,8 @@
+fn main() {
+    tonic_build::configure()
+        .build_client(true)
+        .build_server(true)
+        .out_dir("src/")
+        .compile(&["proto/virtfs.proto"], &["proto"])
+        .unwrap();
+}

--- a/virtfs/virtfs-common/proto/virtfs.proto
+++ b/virtfs/virtfs-common/proto/virtfs.proto
@@ -1,0 +1,10 @@
+import "google/protobuf/empty.proto";
+syntax = "proto3";
+
+service Virtfs {
+  rpc ListLayouts (google.protobuf.Empty) returns (LayoutList);
+  rpc SetLayout (LayoutName) returns (google.protobuf.Empty);
+}
+
+message LayoutName { string name = 1; }
+message LayoutList { repeated string names = 1; }

--- a/virtfs/virtfs-common/src/lib.rs
+++ b/virtfs/virtfs-common/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod virtfs {
+    include!("virtfs.rs");
+}

--- a/virtfs/virtfs-common/src/main.rs
+++ b/virtfs/virtfs-common/src/main.rs
@@ -1,3 +1,0 @@
-fn main() {
-    println!("Hello, world!");
-}

--- a/virtfs/virtfs-gui/Cargo.toml
+++ b/virtfs/virtfs-gui/Cargo.toml
@@ -4,3 +4,6 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+tauri = { version = "2.0.0-beta.6" }
+tokio = { version = "1", features = ["macros"] }
+virtfs-common = { path = "../virtfs-common" }

--- a/virtfs/virtfs-gui/src/main.rs
+++ b/virtfs/virtfs-gui/src/main.rs
@@ -1,3 +1,30 @@
+use tauri::{Builder, command, generate_context};
+use virtfs_common::{virtfs_client::VirtfsClient, LayoutName};
+
+#[command]
+async fn list_layouts() -> Vec<String> {
+    VirtfsClient::connect_uds("/tmp/virtfs.sock")
+        .await
+        .unwrap()
+        .list_layouts(())
+        .await
+        .unwrap()
+        .into_inner()
+        .names
+}
+
+#[command]
+async fn set_layout(name: String) {
+    let _ = VirtfsClient::connect_uds("/tmp/virtfs.sock")
+        .await
+        .unwrap()
+        .set_layout(LayoutName { name })
+        .await;
+}
+
 fn main() {
-    println!("Hello, world!");
+    Builder::default()
+        .invoke_handler(tauri::generate_handler![list_layouts, set_layout])
+        .run(generate_context!())
+        .expect("error running tauri application");
 }

--- a/virtfs/virtfsd/Cargo.toml
+++ b/virtfs/virtfsd/Cargo.toml
@@ -4,3 +4,8 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+fuser = "0.14"
+tokio = { version = "1", features = ["rt-multi-thread", "signal"] }
+tonic = "0.11"
+serde = { version = "1", features = ["derive"] }
+virtfs-common = { path = "../virtfs-common" }

--- a/virtfs/virtfsd/src/main.rs
+++ b/virtfs/virtfsd/src/main.rs
@@ -1,3 +1,52 @@
-fn main() {
-    println!("Hello, world!");
+use fuser::{Filesystem, MountOption, ReplyDirectory, Request};
+use std::{ffi::OsStr, path::PathBuf};
+use tokio::{signal, task};
+use virtfs_common::virtfs_server::{Virtfs, VirtfsServer};
+use virtfs_common::{LayoutList, LayoutName};
+
+struct Vfs;
+
+impl Filesystem for Vfs {
+    fn readdir(&mut self, _req: &Request<'_>, _ino: u64, _fh: u64, _offset: i64, mut reply: ReplyDirectory) {
+        reply.ok();
+    }
+}
+
+async fn switch_layout(_name: &str) {
+    // placeholder for switching logic
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let mountpoint = PathBuf::from("/tmp/virtfs");
+    let fs = Vfs;
+
+    let fuse_task = task::spawn_blocking(move || {
+        fuser::mount2(fs, &mountpoint, &[MountOption::FSName("virtfs"), MountOption::RO]).unwrap();
+    });
+
+    struct RpcSvc;
+    #[tonic::async_trait]
+    impl Virtfs for RpcSvc {
+        async fn list_layouts(&self, _req: tonic::Request<()>) -> tonic::Result<tonic::Response<LayoutList>> {
+            Ok(tonic::Response::new(LayoutList { names: vec![] }))
+        }
+        async fn set_layout(&self, req: tonic::Request<LayoutName>) -> tonic::Result<tonic::Response<()>> {
+            switch_layout(&req.into_inner().name).await;
+            Ok(tonic::Response::new(()))
+        }
+    }
+
+    let uds = tokio::net::UnixListener::bind("/tmp/virtfs.sock")?;
+    let grpc = tonic::transport::Server::builder()
+        .add_service(VirtfsServer::new(RpcSvc))
+        .serve_with_incoming(tokio_stream::wrappers::UnixListenerStream::new(uds));
+
+    tokio::select! {
+        _ = fuse_task => {},
+        _ = grpc => {},
+        _ = signal::ctrl_c() => {}
+    }
+
+    Ok(())
 }


### PR DESCRIPTION
## Summary
- add proto definition for Virtfs gRPC service
- generate tonic stubs in build script
- implement minimal virtfs daemon with FUSE mount and gRPC server
- add Tauri stub GUI communicating over gRPC
- ignore build artefacts

## Testing
- `cargo build` *(fails: spurious network error, CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_686addf94bac83299e5bf0a566b2ac85