### PR TITLE
Fix proto compiler error

### DIFF
--- a/virtfs/virtfs-common/proto/google/protobuf/empty.proto
+++ b/virtfs/virtfs-common/proto/google/protobuf/empty.proto
@@ -1,0 +1,4 @@
+syntax = "proto3";
+package google.protobuf;
+
+message Empty {}

--- a/virtfs/virtfs-common/proto/virtfs.proto
+++ b/virtfs/virtfs-common/proto/virtfs.proto
@@ -1,5 +1,5 @@
-import "google/protobuf/empty.proto";
 syntax = "proto3";
+import "google/protobuf/empty.proto";
 
 service Virtfs {
   rpc ListLayouts (google.protobuf.Empty) returns (LayoutList);


### PR DESCRIPTION
## Summary
- vendor Google's empty proto to satisfy build requirements

## Testing
- `cargo build -p virtfs-gui --manifest-path virtfs/Cargo.toml` *(fails: failed to download from index.crates.io)*


------
https://chatgpt.com/codex/tasks/task_e_686ae34d87308329812475b87e07dc23